### PR TITLE
Feature/#3 - Prefetch 기능 추가

### DIFF
--- a/GifSearchApp/Presentation/SearchGif/SearchGifViewController.swift
+++ b/GifSearchApp/Presentation/SearchGif/SearchGifViewController.swift
@@ -121,12 +121,9 @@ extension SearchGifViewController: UICollectionViewDelegate {
 
 extension SearchGifViewController: UICollectionViewDataSourcePrefetching {
     func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
-//        print("😈😈😈😈😈😈😈😈test")
-//        if !indexPaths.isEmpty {
-//            for index in indexPaths {
-//                print(index.row, terminator: " ")
-//            }
-//        }
+        indexPaths.forEach {
+            searchGifViewModel.prefetchGif(at: $0)
+        }
     }
 }
 

--- a/GifSearchApp/Presentation/SearchGif/SearchGifViewModel.swift
+++ b/GifSearchApp/Presentation/SearchGif/SearchGifViewModel.swift
@@ -110,25 +110,3 @@ extension SearchGifViewModel {
         }
     }
 }
-
-extension SearchGifViewModel {
-    func reloadSnapshot(with gif: Gif) {
-        var newSnapshot = self.dataSource.snapshot()
-        newSnapshot.reloadItems([gif])
-        DispatchQueue.main.async {
-            self.dataSource.apply(newSnapshot)
-        }
-    }
-    
-    func applySnapshot(with gifs: [Gif], completion: @escaping () -> ()) {
-        var newSnapshot = self.dataSource.snapshot()
-        if newSnapshot.sectionIdentifiers.isEmpty {
-            newSnapshot.appendSections([.main])
-        }
-        newSnapshot.appendItems(gifs, toSection: .main)
-        DispatchQueue.main.async {
-            self.dataSource.apply(newSnapshot)
-            completion()
-        }
-    }
-}

--- a/GifSearchApp/Presentation/SearchGif/SearchGifViewModel.swift
+++ b/GifSearchApp/Presentation/SearchGif/SearchGifViewModel.swift
@@ -48,6 +48,14 @@ class SearchGifViewModel {
         currentPage = Page()
         fetchGifInfos()
     }
+    
+    func prefetchGif(at indexPath: IndexPath) {
+        guard let gif = dataSource.itemIdentifier(for: indexPath) else {
+            return
+        }
+        
+        imageCache.prefetchGif(for: gif)
+    }
 }
 
 extension SearchGifViewModel {
@@ -66,7 +74,6 @@ extension SearchGifViewModel {
             switch result {
             case .success(let data):
                 _self.currentPage = data.toDomainPage()
-                print(_self.currentPage.offset)
                 let gifInfos = data.toDomainGif()
                 var snapshot = _self.dataSource.snapshot()
                 if snapshot.sectionIdentifiers.isEmpty {


### PR DESCRIPTION
# 🛠 변경사항 및 구현한 기능
- `prefetchItemsAt` 함수에 `NSCache` 기능 추가 #3

## 🤔 고민한 점
- `prefetchItemsAt`함수는 화면에서 보이지 않는 `indexPath`를 미리 예측해서 알려준다.
이 `indexPath`를 가지고 무얼 할 수 있을까??

## 🙌 해결한 방법
- `indexPath`에 해당하는 `Gif` 이미지 데이터가 아직 다운로드 되지 않았으면 네트워크 요청, 캐시에 저장

## ✅ PR 포인트
- `ImageCache`클래스의 `prefetchGif`함수에서 모든 캐싱이 일어나서 이 부분만 보셔도 될듯합니당
